### PR TITLE
Updated readme to include adding philo-search-core

### DIFF
--- a/src/Philo.Search.Vue/README.md
+++ b/src/Philo.Search.Vue/README.md
@@ -3,3 +3,9 @@ Vue Component to present and build query filters on top of https://www.nuget.org
 Provide the row data schema and this component will generate filter fields automatically. 
 
 Offers complex table data queries, searching, and sorting without the need to wire everything up each time.
+
+## Install instructions
+```npm install philo-search-vue philo-search-core```
+
+## Notes
+You may run into build errors if you don't install philo-search-core as a dependency


### PR DESCRIPTION
npm install inside of Docker build fails if philo-search-core is not added as a dependency